### PR TITLE
Update for python 3.12

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,7 @@ on:
     branches: [main]
   schedule:
     - cron: "21 0 * * 6"
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
 
     strategy:
       matrix:
-        target: ["3.9", "3.10", "3.11"]
+        target: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: build
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
@@ -56,7 +57,6 @@ dev = [
     "pylint",
     "pytest",
     "pytest-cov",
-    "types-pkg-resources",
     "types-pyyaml",
 ]
 
@@ -67,7 +67,7 @@ Tracker = "https://github.com/pennsignals/cfgenvy/issues"
 
 [tool.black]
 line-length = 79
-target-version = ["py39","py310","py311"]
+target-version = ["py39","py310","py311","py312"]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -83,7 +83,7 @@ branch = true
 parallel = true
 
 [tool.distutils.bdist_wheel]
-python-tag = "py39.py310.py311"
+python-tag = "py39.py310.py311.py312"
 
 [tool.isort]
 include_trailing_comma = true

--- a/src/cfgenvy/yaml.py
+++ b/src/cfgenvy/yaml.py
@@ -67,7 +67,7 @@ def yaml_type(
     loader: type[MyLoader] | None = None,
     dumper: type[MyDumper] | None = None,
     **kwargs,
-):
+):  # pylint: disable=too-many-arguments
     """Yaml type."""
     if init is not None:
 
@@ -96,7 +96,7 @@ def yaml_implicit_type(
     loader: type[MyLoader] | None = None,
     dumper: type[MyDumper] | None = None,
     **kwargs,
-):
+):  # pylint: disable=too-many-arguments
     """Yaml implicit type."""
 
     def _init_closure(loader, node):


### PR DESCRIPTION
Update for python 3.12.
Remove any dependency on pkg_resources; a deprecated method of inspecting package versions incompatible with recent pip.

Closes #11 